### PR TITLE
Implement multi-bot JSON token config

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,9 +8,7 @@
 Copyright (c) 2024 Wick Studio
 */
 
-module.exports = {    
-    token: "", // token
-    clientId: "", // bot id
+module.exports = {
     prefix: "!", // prefix
     language: "ar", // ar for arabic | en for english
     verbose: true,

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ const path = require("path");
 const fs = require("fs");
 const { registerCustomFonts } = require("./src/utils/registerFonts");
 const config = require("./config.js");
+const tokens = require("./tokens.json");
 const sodium = require('libsodium-wrappers');
 const Localization = require("./src/utils/localization");
 
-(async () => {
+async function startBot({ token, clientId, voiceChannelId, logChannelId, main }) {
     try {
         await sodium.ready;
 
@@ -25,7 +26,26 @@ const Localization = require("./src/utils/localization");
             partials: [Partials.Channel],
         });
 
-        client.config = config;
+        client.config = { ...config, token, clientId, voiceChannelId, logChannelId };
+        if (!main) {
+            client.config.enableLogging = false;
+        }
+        client.isMain = !!main;
+
+        client.log = async (msg) => {
+            if (!client.config.enableLogging) return;
+            console.log(msg);
+            if (client.isMain && client.config.logChannelId) {
+                try {
+                    const channel = await client.channels.fetch(client.config.logChannelId);
+                    if (channel && typeof channel.send === 'function') {
+                        await channel.send(msg);
+                    }
+                } catch (err) {
+                    console.error('❌ Failed to send log message:', err);
+                }
+            }
+        };
 
         client.localization = new Localization(client);
 
@@ -39,13 +59,13 @@ const Localization = require("./src/utils/localization");
             const command = require(filePath);
             if ("name" in command && "execute" in command) {
                 client.commands.set(command.name, command);
-                console.log(`✅ Loaded command: ${command.name}`);
+                client.log(`✅ Loaded command: ${command.name}`);
 
                 const aliases = config.aliases[command.name];
                 if (aliases && Array.isArray(aliases)) {
                     aliases.forEach(alias => {
                         client.commands.set(alias, command);
-                        console.log(`✅ Registered alias '${alias}' for command '${command.name}'`);
+                        client.log(`✅ Registered alias '${alias}' for command '${command.name}'`);
                     });
                 }
             } else {
@@ -59,13 +79,13 @@ const Localization = require("./src/utils/localization");
         for (const file of eventFiles) {
             const filePath = path.join(eventsPath, file);
             const event = require(filePath);
-            if (event.once) {
-                client.once(event.name, (...args) => event.execute(...args, client));
-                console.log(`📂 Loaded event (once): ${event.name} from ${filePath}`);
-            } else {
-                client.on(event.name, (...args) => event.execute(...args, client));
-                console.log(`📂 Loaded event: ${event.name} from ${filePath}`);
-            }
+                if (event.once) {
+                    client.once(event.name, (...args) => event.execute(...args, client));
+                    client.log(`📂 Loaded event (once): ${event.name} from ${filePath}`);
+                } else {
+                    client.on(event.name, (...args) => event.execute(...args, client));
+                    client.log(`📂 Loaded event: ${event.name} from ${filePath}`);
+                }
         }
 
         client.distube = new DisTube(client, {
@@ -86,7 +106,7 @@ const Localization = require("./src/utils/localization");
                     }
 
                     if (client.config.enableLogging) {
-                        console.log(client.localization.get('events.playSong', { song: song.name, user: song.user.tag }));
+                        client.log(client.localization.get('events.playSong', { song: song.name, user: song.user.tag }));
                     }
 
                     if (queue.currentMessage) {
@@ -109,7 +129,7 @@ const Localization = require("./src/utils/localization");
                     }
 
                     if (client.config.enableLogging) {
-                        console.log(client.localization.get('events.addSong', { song: song.name, duration: formatTime(song.duration), user: song.user.tag }));
+                        client.log(client.localization.get('events.addSong', { song: song.name, duration: formatTime(song.duration), user: song.user.tag }));
                     }
 
                     if (queue.textChannel && typeof queue.textChannel.send === "function") {
@@ -125,11 +145,32 @@ const Localization = require("./src/utils/localization");
                     console.error("❌ Error in addSong event:", error);
                 }
             })
-        await client.login(client.config.token);
-        console.log("🚀 Bot is online!");
+        await client.login(token);
+        client.log(`🚀 Bot ${client.user.tag} is online!`);
+        return client;
     } catch (error) {
         console.error("❌ Failed to initialize the bot:", error);
-        process.exit(1);
+    }
+}
+
+const tokensToUse = Array.isArray(tokens) ? tokens : [];
+if (tokensToUse.length === 0) {
+    console.error('❌ No bot tokens found in tokens.json');
+    process.exit(1);
+}
+
+const clients = [];
+let mainClient;
+
+(async () => {
+    for (const botConfig of tokensToUse) {
+        const client = await startBot(botConfig);
+        if (client) {
+            clients.push(client);
+            if (botConfig.main && !mainClient) {
+                mainClient = client;
+            }
+        }
     }
 })();
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ The `config.js` file allows you to customize the bot's behavior. Below are the a
 The `tokens.json` file holds your bot tokens:
 - **token:** The bot token.
 - **clientId:** The Discord application client ID.
-- **voiceChannelId:** Default voice channel the bot should join.
+- **voiceChannelId:** Default voice channel the bot should join. The bot will automatically connect to this channel on startup.
 - **logChannelId:** Channel ID used by the main bot for logs.
 - **main:** Set to `true` only for the main bot.
 

--- a/readme.md
+++ b/readme.md
@@ -40,36 +40,25 @@
 
 3. **Configure the Bot:**
 
-   - Rename `config.example.js` to `config.js`.
-   - Fill in the required fields in `config.js` with your bot's token, client ID, and other configurations.
+   - Create a `config.js` file and adjust the general settings (prefix, language, etc.).
+   - Add your bot tokens and related information inside `tokens.json`.
 
-   ```javascript
-   // config.js
-
-   module.exports = {    
-       token: "YOUR_BOT_TOKEN", // Your bot's token
-       clientId: "YOUR_CLIENT_ID", // Your bot's client ID
-       prefix: "!", // Command prefix
-       language: "en", // 'ar' for Arabic | 'en' for English
-       verbose: true,
-       musicCardPath: "./musicard.png",
-       enableLogging: true,
-       djRoleName: "DJ",
-       aliases: {
-         play: ["p", "start", "playmusic"],
-         pause: ["hold", "stopmusic"],
-         resume: ["r", "continue"],
-         skip: ["s", "next", "jump"],
-         stop: ["end", "terminate"],
-         volumeUp: ["vup", "increasevolume"],
-         volumeDown: ["vdown", "decreasevolume"],
-         repeat: ["loop"],
-         queue: ["q"],
-         nowplaying: ["np"],
-         clear: ["c"],
-         remove: ["rm", "delete"]
-       }
-   };
+   ```json
+   // tokens.json
+   [
+     {
+       token: "MAIN_BOT_TOKEN",
+       clientId: "MAIN_CLIENT_ID",
+       voiceChannelId: "VOICE_CHANNEL_ID",
+       logChannelId: "LOG_CHANNEL_ID",
+       main: true
+     },
+     {
+       token: "SECONDARY_BOT_TOKEN",
+       clientId: "SECONDARY_CLIENT_ID",
+       voiceChannelId: "VOICE_CHANNEL_ID"
+     }
+   ]
    ```
 
 4. **Register Custom Fonts:**
@@ -88,8 +77,6 @@
 
 The `config.js` file allows you to customize the bot's behavior. Below are the available configurations:
 
-- **token:** Your Discord bot token.
-- **clientId:** Your Discord bot's client ID.
 - **prefix:** The prefix used for bot commands (e.g., `!play`).
 - **language:** Set to `'ar'` for Arabic or `'en'` for English.
 - **verbose:** Enable or disable verbose logging.
@@ -97,6 +84,15 @@ The `config.js` file allows you to customize the bot's behavior. Below are the a
 - **enableLogging:** Toggle logging of events and errors.
 - **djRoleName:** Name of the role that has DJ permissions.
 - **aliases:** Define command aliases for easier access.
+
+The `tokens.json` file holds your bot tokens:
+- **token:** The bot token.
+- **clientId:** The Discord application client ID.
+- **voiceChannelId:** Default voice channel the bot should join.
+- **logChannelId:** Channel ID used by the main bot for logs.
+- **main:** Set to `true` only for the main bot.
+
+Bot tokens, client IDs and default voice channels are defined in `tokens.json`.
 
 ## 🎮 Usage
 

--- a/src/events/distube/addList.js
+++ b/src/events/distube/addList.js
@@ -8,7 +8,7 @@ module.exports = {
                 queue.textChannel = playlist.metadata.message.channel;
             }
 
-            if (queue.client.config.enableLogging) console.log(`🎶 Added playlist: ${playlist.name} | ${playlist.songs.length} songs`);
+            if (queue.client.config.enableLogging) queue.client.log(`🎶 Added playlist: ${playlist.name} | ${playlist.songs.length} songs`);
 
             if (queue.textChannel && typeof queue.textChannel.send === "function") {
                 const embed = new EmbedBuilder()

--- a/src/events/distube/addSong.js
+++ b/src/events/distube/addSong.js
@@ -9,7 +9,7 @@ module.exports = {
                 queue.textChannel = song.metadata.message.channel;
             }
 
-            if (queue.client.config.enableLogging) console.log(queue.client.localization.get('events.addSong', { song: song.name, duration: formatTime(song.duration), user: song.user.tag }));
+            if (queue.client.config.enableLogging) queue.client.log(queue.client.localization.get('events.addSong', { song: song.name, duration: formatTime(song.duration), user: song.user.tag }));
 
             if (queue.textChannel && typeof queue.textChannel.send === "function") {
                 const embed = new EmbedBuilder()

--- a/src/events/distube/playSong.js
+++ b/src/events/distube/playSong.js
@@ -8,7 +8,7 @@ module.exports = {
             if (!queue.textChannel) {
                 if (song.metadata && song.metadata.message && song.metadata.message.channel) {
                     queue.textChannel = song.metadata.message.channel;
-                    console.log('✅ Text channel successfully assigned from metadata.');
+                    if (client.config.enableLogging) client.log('✅ Text channel successfully assigned from metadata.');
                 } else {
                     console.error('❌ No valid text channel found for queue.');
                     return;
@@ -16,7 +16,7 @@ module.exports = {
             }
 
             if (client.config.enableLogging) {
-                console.log(client.localization.get('events.playSong', { song: song.name, user: song.user.tag }));
+                client.log(client.localization.get('events.playSong', { song: song.name, user: song.user.tag }));
             }
 
             if (queue.currentMessage) {
@@ -27,9 +27,9 @@ module.exports = {
                 queue.initiatorId = undefined;
             }
 
-            console.log('ℹ️ Attempting to send music card...');
+            if (client.config.enableLogging) client.log('ℹ️ Attempting to send music card...');
             await sendMusicCard(queue, song, client.localization);
-            console.log('✅ Music card sent successfully.');
+            if (client.config.enableLogging) client.log('✅ Music card sent successfully.');
         } catch (error) {
             console.error('❌ Error in playSong event:', error);
         }

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -6,6 +6,13 @@ module.exports = {
         if (message.author.bot) return;
         if (!message.content.startsWith(client.config.prefix)) return;
 
+        if (client.config.voiceChannelId) {
+            const userChannel = message.member?.voice?.channelId;
+            if (!userChannel || userChannel !== client.config.voiceChannelId) {
+                return;
+            }
+        }
+
         const args = message.content.slice(client.config.prefix.length).trim().split(/ +/);
         const commandName = args.shift().toLowerCase();
 

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,5 +1,4 @@
 const { ActivityType } = require("discord.js");
-const { joinVoiceChannel } = require("@discordjs/voice");
 const chalk = require("chalk");
 const moment = require("moment");
 require("moment-duration-format");
@@ -60,12 +59,7 @@ ${chalk.greenBright("            © Wick® Studio")}
                 try {
                     const channel = await client.channels.fetch(client.config.voiceChannelId);
                     if (channel && channel.isVoiceBased()) {
-                        joinVoiceChannel({
-                            channelId: channel.id,
-                            guildId: channel.guild.id,
-                            adapterCreator: channel.guild.voiceAdapterCreator,
-                            selfDeaf: false,
-                        });
+                        await client.distube.voices.join(channel, { selfDeaf: false });
                         if (client.config.enableLogging) {
                             client.log(chalk.cyanBright(`🔊 Joined voice channel: ${channel.name}`));
                         }

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -21,33 +21,39 @@ ${chalk.blueBright(`
 `)}
 ${chalk.greenBright("            © Wick® Studio")}    
 `;
-            console.log(banner);
-            console.log(chalk.yellowBright(`✅ Logged in as ${client.user.tag}!`));
-            console.log('Code by Wick Studio');
-            console.log('join us at : discord.gg/wicks');
+            if (client.config.enableLogging) {
+                client.log(banner);
+                client.log(chalk.yellowBright(`✅ Logged in as ${client.user.tag}!`));
+                client.log('Code by Wick Studio');
+                client.log('join us at : discord.gg/wicks');
+            }
 
             const memoryUsage = (process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2);
             const uptime = moment.duration(client.uptime).format(" D [days], H [hrs], m [mins], s [secs]");
             const cpuLoad = os.loadavg()[0].toFixed(2);
 
-            console.log(chalk.cyanBright(`📁 Guilds: ${client.guilds.cache.size}`));
-            console.log(chalk.cyanBright(`👥 Users: ${client.users.cache.size}`));
-            console.log(chalk.cyanBright(`🖥️ Memory Usage: ${memoryUsage} MB`));
-            console.log(chalk.cyanBright(`🖥️ CPU Load (1m): ${cpuLoad}`));
-            console.log(chalk.cyanBright(`⏱️ Uptime: ${uptime}`));
+            if (client.config.enableLogging) {
+                client.log(chalk.cyanBright(`📁 Guilds: ${client.guilds.cache.size}`));
+                client.log(chalk.cyanBright(`👥 Users: ${client.users.cache.size}`));
+                client.log(chalk.cyanBright(`🖥️ Memory Usage: ${memoryUsage} MB`));
+                client.log(chalk.cyanBright(`🖥️ CPU Load (1m): ${cpuLoad}`));
+                client.log(chalk.cyanBright(`⏱️ Uptime: ${uptime}`));
+            }
 
             try {
                 const presence = await client.user.setActivity("🔊 Discord Player!", { type: ActivityType.Playing });
                 if (presence.activities.length > 0) {
-                    console.log(chalk.magentaBright(`🔔 Activity set to "${presence.activities[0].name}"`));
+                    if (client.config.enableLogging) client.log(chalk.magentaBright(`🔔 Activity set to "${presence.activities[0].name}"`));
                 } else {
-                    console.log(chalk.magentaBright(`🔔 Activity set to "🔊 Discord Player!"`));
+                    if (client.config.enableLogging) client.log(chalk.magentaBright(`🔔 Activity set to "🔊 Discord Player!"`));
                 }
             } catch (err) {
                 console.error(chalk.redBright("❌ Failed to set initial activity:"), err);
             }
-            console.log(chalk.greenBright("✅ Bot is fully operational and ready to serve!"));
-            console.log(chalk.yellowBright("📜 Copyright Wick® Studio"));
+            if (client.config.enableLogging) {
+                client.log(chalk.greenBright("✅ Bot is fully operational and ready to serve!"));
+                client.log(chalk.yellowBright("📜 Copyright Wick® Studio"));
+            }
         } catch (error) {
             console.error(chalk.redBright("❌ Error in ready event:"), error);
         }

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -56,19 +56,23 @@ ${chalk.greenBright("            © Wick® Studio")}
             }
 
             if (client.config.voiceChannelId) {
-                try {
-                    const channel = await client.channels.fetch(client.config.voiceChannelId);
-                    if (channel && channel.isVoiceBased()) {
-                        await client.distube.voices.join(channel, { selfDeaf: false });
-                        if (client.config.enableLogging) {
-                            client.log(chalk.cyanBright(`🔊 Joined voice channel: ${channel.name}`));
+                const joinDefault = async () => {
+                    try {
+                        const channel = await client.channels.fetch(client.config.voiceChannelId);
+                        if (channel && channel.isVoiceBased()) {
+                            await client.distube.voices.join(channel, { selfDeaf: false });
+                            if (client.config.enableLogging) {
+                                client.log(chalk.cyanBright(`🔊 Joined voice channel: ${channel.name}`));
+                            }
+                        } else if (client.config.enableLogging) {
+                            client.log(chalk.redBright("❌ Provided voiceChannelId is not voice based."));
                         }
-                    } else if (client.config.enableLogging) {
-                        client.log(chalk.redBright("❌ Provided voiceChannelId is not voice based."));
+                    } catch (err) {
+                        console.error(chalk.redBright("❌ Failed to join voice channel:"), err);
                     }
-                } catch (err) {
-                    console.error(chalk.redBright("❌ Failed to join voice channel:"), err);
-                }
+                };
+                // Delay joining slightly to ensure all caches are ready
+                setTimeout(joinDefault, 1000);
             }
         } catch (error) {
             console.error(chalk.redBright("❌ Error in ready event:"), error);

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,4 +1,5 @@
 const { ActivityType } = require("discord.js");
+const { joinVoiceChannel } = require("@discordjs/voice");
 const chalk = require("chalk");
 const moment = require("moment");
 require("moment-duration-format");
@@ -53,6 +54,27 @@ ${chalk.greenBright("            © Wick® Studio")}
             if (client.config.enableLogging) {
                 client.log(chalk.greenBright("✅ Bot is fully operational and ready to serve!"));
                 client.log(chalk.yellowBright("📜 Copyright Wick® Studio"));
+            }
+
+            if (client.config.voiceChannelId) {
+                try {
+                    const channel = await client.channels.fetch(client.config.voiceChannelId);
+                    if (channel && channel.isVoiceBased()) {
+                        joinVoiceChannel({
+                            channelId: channel.id,
+                            guildId: channel.guild.id,
+                            adapterCreator: channel.guild.voiceAdapterCreator,
+                            selfDeaf: false,
+                        });
+                        if (client.config.enableLogging) {
+                            client.log(chalk.cyanBright(`🔊 Joined voice channel: ${channel.name}`));
+                        }
+                    } else if (client.config.enableLogging) {
+                        client.log(chalk.redBright("❌ Provided voiceChannelId is not voice based."));
+                    }
+                } catch (err) {
+                    console.error(chalk.redBright("❌ Failed to join voice channel:"), err);
+                }
             }
         } catch (error) {
             console.error(chalk.redBright("❌ Error in ready event:"), error);

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -87,8 +87,8 @@
       }
     },
     "events": {
-      "playPlayer": "🔊 Playing: {Player} | Requested by: {user}",
-      "addPlayer": "🔊 Added `{Player}` - `{duration}` to the queue by {user}",
+      "playSong": "🔊 Playing: {song} | Requested by: {user}",
+      "addSong": "🔊 Added `{song}` - `{duration}` to the queue by {user}",
       "addList": "🔊 Added `{playlist}` playlist ({count} Players) to queue\nVolume: `{volume}%` | Loop: `{loop}`",
       "empty": "⛔ Voice channel is empty! Leaving the channel...",
       "finish": "🏁 Queue finished!",

--- a/tokens.json
+++ b/tokens.json
@@ -1,0 +1,15 @@
+[
+  {
+    "token": "MAIN_BOT_TOKEN",
+    "clientId": "MAIN_CLIENT_ID",
+    "voiceChannelId": "VOICE_CHANNEL_ID",
+    "logChannelId": "LOG_CHANNEL_ID",
+    "main": true
+  },
+  {
+    "token": "SECONDARY_BOT_TOKEN",
+    "clientId": "SECONDARY_CLIENT_ID",
+    "voiceChannelId": "VOICE_CHANNEL_ID"
+  }
+]
+


### PR DESCRIPTION
## Summary
- remove token info from `config.js`
- convert `tokens.js` to `tokens.json`
- load all bots from `tokens.json`
- add log channel support for the main bot only
- disable logging for secondary bots
- document the new setup in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868815b2a3c832994378e4e644037e6